### PR TITLE
prod 환경 로깅 시스템 구현

### DIFF
--- a/src/main/java/com/fesi/mukitlist/logging/LogTraceAspect.java
+++ b/src/main/java/com/fesi/mukitlist/logging/LogTraceAspect.java
@@ -1,0 +1,43 @@
+package com.fesi.mukitlist.logging;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+
+import com.fesi.mukitlist.logging.trace.LogTrace;
+import com.fesi.mukitlist.logging.trace.TraceStatus;
+
+@Aspect
+@Component
+public class LogTraceAspect {
+
+	private final LogTrace logTrace;
+
+	public LogTraceAspect(LogTrace logTrace) {
+		this.logTrace = logTrace;
+	}
+
+	@Around("allControllerMethods()")
+	public Object execute(ProceedingJoinPoint joinPoint) throws Throwable {
+		TraceStatus status = null;
+		try {
+			String message = joinPoint.getSignature().toShortString();
+			status = logTrace.begin(message);
+
+			Object result = joinPoint.proceed();
+
+			logTrace.end(status);
+			return result;
+		} catch (Exception e) {
+			logTrace.exception(status, e);
+			throw e;
+		}
+	}
+
+	@Pointcut("execution(* com.fesi.mukitlist.api.controller..*.*(..))")
+	public void allControllerMethods() {
+	}
+
+}

--- a/src/main/java/com/fesi/mukitlist/logging/trace/LogTrace.java
+++ b/src/main/java/com/fesi/mukitlist/logging/trace/LogTrace.java
@@ -1,0 +1,10 @@
+package com.fesi.mukitlist.logging.trace;
+
+public interface LogTrace {
+
+	TraceStatus begin(String message);
+
+	void end(TraceStatus status);
+
+	void exception(TraceStatus status, Exception e);
+}

--- a/src/main/java/com/fesi/mukitlist/logging/trace/ThreadLocalLogTrace.java
+++ b/src/main/java/com/fesi/mukitlist/logging/trace/ThreadLocalLogTrace.java
@@ -1,0 +1,78 @@
+package com.fesi.mukitlist.logging.trace;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ThreadLocalLogTrace implements LogTrace {
+
+	private static final String START_PREFIX = "-->";
+	private static final String COMPLETE_PREFIX = "<--";
+	private static final String EX_PREFIX = "<X-";
+
+	private final ThreadLocal<TraceId> traceIdHolder = new ThreadLocal<>();
+	private final Logger log = LoggerFactory.getLogger(getClass());
+
+	@Override
+	public TraceStatus begin(String message) {
+		syncTraceId();
+		TraceId traceId = traceIdHolder.get();
+		Long startTimeMs = System.currentTimeMillis();
+		log.info("[{}] Start {}{}", traceId.getId(), addSpace(START_PREFIX, traceId.getLevel()), message);
+
+		return new TraceStatus(traceId, startTimeMs, message);
+	}
+
+	@Override
+	public void end(TraceStatus status) {
+		complete(status, null);
+	}
+
+	@Override
+	public void exception(TraceStatus status, Exception e) {
+		complete(status, e);
+	}
+
+	private void complete(TraceStatus status, Exception e) {
+		Long stopTimeMs = System.currentTimeMillis();
+		long resultTimeMs = stopTimeMs - status.getStartTimeMs();
+		TraceId traceId = status.getTraceId();
+		if (e == null) {
+			log.info("[{}] End   {}{} time={}ms", traceId.getId(), addSpace(COMPLETE_PREFIX, traceId.getLevel()),
+				status.getMessage(), resultTimeMs);
+		} else {
+			log.error("[{}] Error {}{} time={}ms ex={}", traceId.getId(), addSpace(EX_PREFIX, traceId.getLevel()),
+				status.getMessage(), resultTimeMs, e.toString());
+		}
+
+		releaseTraceId();
+	}
+
+	private void syncTraceId() {
+		TraceId traceId = traceIdHolder.get();
+		if (traceId == null) {
+			traceIdHolder.set(new TraceId());
+		} else {
+			traceIdHolder.set(traceId.createNextId());
+		}
+	}
+
+	private void releaseTraceId() {
+		TraceId traceId = traceIdHolder.get();
+		if (traceId.isFirstLevel()) {
+			traceIdHolder.remove();
+		} else {
+			traceIdHolder.set(traceId.createPreviousId());
+		}
+	}
+
+	private static String addSpace(String prefix, int level) {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < level; i++) {
+			sb.append((i == level - 1) ? "|" + prefix : "|   ");
+		}
+		return sb.toString();
+	}
+}
+

--- a/src/main/java/com/fesi/mukitlist/logging/trace/TraceId.java
+++ b/src/main/java/com/fesi/mukitlist/logging/trace/TraceId.java
@@ -1,0 +1,43 @@
+package com.fesi.mukitlist.logging.trace;
+
+import java.util.UUID;
+
+public class TraceId {
+
+	private String id;
+	private int level;
+
+	public TraceId() {
+		this.id = createId();
+		this.level = 0;
+	}
+
+	private TraceId(String id, int level) {
+		this.id = id;
+		this.level = level;
+	}
+
+	private String createId() {
+		return UUID.randomUUID().toString().substring(0, 8);
+	}
+
+	public TraceId createNextId() {
+		return new TraceId(id, level + 1);
+	}
+
+	public TraceId createPreviousId() {
+		return new TraceId(id, level - 1);
+	}
+
+	public boolean isFirstLevel() {
+		return level == 0;
+	}
+
+	public String getId() {
+		return id;
+	}
+
+	public int getLevel() {
+		return level;
+	}
+}

--- a/src/main/java/com/fesi/mukitlist/logging/trace/TraceStatus.java
+++ b/src/main/java/com/fesi/mukitlist/logging/trace/TraceStatus.java
@@ -1,0 +1,26 @@
+package com.fesi.mukitlist.logging.trace;
+
+public class TraceStatus {
+
+	private TraceId traceId;
+	private Long startTimeMs;
+	private String message;
+
+	public TraceStatus(TraceId traceId, Long startTimeMs, String message) {
+		this.traceId = traceId;
+		this.startTimeMs = startTimeMs;
+		this.message = message;
+	}
+
+	public Long getStartTimeMs() {
+		return startTimeMs;
+	}
+
+	public String getMessage() {
+		return message;
+	}
+
+	public TraceId getTraceId() {
+		return traceId;
+	}
+}


### PR DESCRIPTION
## 연관된 이슈
- #41 
- #40 

## 작업 내용

prod에서 로그를 확인할 수 없어 문제 대응이 늦어지는 것 같아 적어도 바로 확인할 수 있게 로깅을 달았습니다.
aop는 controller 단에서만 동작하며, 사용자가 호출한 엔드포인트를 추적하고 문제의 원인을 빠르게 파악하기 위해 달았습니다.

## 코멘트


